### PR TITLE
Update .gitignore for macOS, add "the osname" and "the osversion"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ bundles/
 /wyldcard.jar
 /.scannerwork
 Thumbs.db
+
+.DS_Store

--- a/src/main/antlr/com/defano/hypertalk/parser/HyperTalk.g4
+++ b/src/main/antlr/com/defano/hypertalk/parser/HyperTalk.g4
@@ -557,6 +557,8 @@ zeroArgFunc
     | 'mouseclick'                                                                                                      # mouseClickFunc
     | 'mouseloc'                                                                                                        # mouseLocFunc
     | 'optionkey'                                                                                                       # optionKeyFunc
+    | 'osname'                                                                                                          # OSNameFunc
+    | 'osversion'                                                                                                       # OSVersionFunc
     | 'result'                                                                                                          # resultFunc
     | 'screenrect'                                                                                                      # screenRectFunc
     | seconds                                                                                                           # secondsFunc
@@ -775,7 +777,7 @@ keyword
     | 'white' | 'dissolve' | 'barn' | 'door' | 'checkerboard' | 'iris' | 'shrink' | 'stretch' | 'venetian' | 'blinds'
     | 'wipe' | 'zoom' | 'in' | 'out' | 'tick' | 'prev' | 'previous' | 'msg' | 'box' | 'cards' | 'cds' | 'cd'
     | 'background' | 'backgrounds' | 'bkgnd' | 'bkgnds' | 'bg' | 'bgs' | 'buttons' | 'btn' | 'btns' | 'fields' | 'fld'
-    | 'flds' | 'character' | 'characters' | 'char' | 'words' | 'lines' | 'item' | 'items' | 'of'
+    | 'flds' | 'character' | 'characters' | 'char' | 'words' | 'lines' | 'item' | 'items' | 'of' | 'osname' | 'osversion'
     ;
 
 picture

--- a/src/main/java/com/defano/hypertalk/HyperTalkTreeVisitor.java
+++ b/src/main/java/com/defano/hypertalk/HyperTalkTreeVisitor.java
@@ -2455,6 +2455,16 @@ public class HyperTalkTreeVisitor extends HyperTalkBaseVisitor<Object> {
     }
 
     @Override
+    public Object visitOSNameFunc(HyperTalkParser.OSNameFuncContext ctx) {
+        return BuiltInFunction.OSNAME;
+    }
+
+    @Override
+    public Object visitOSVersionFunc(HyperTalkParser.OSVersionFuncContext ctx) {
+        return BuiltInFunction.OSVERSION;
+    }
+
+    @Override
     public Object visitLongTimeFormat(HyperTalkParser.LongTimeFormatContext ctx) {
         return LengthAdjective.LONG;
     }

--- a/src/main/java/com/defano/hypertalk/ast/expression/function/OSNameFunc.java
+++ b/src/main/java/com/defano/hypertalk/ast/expression/function/OSNameFunc.java
@@ -1,0 +1,42 @@
+package com.defano.hypertalk.ast.expression.function;
+
+import com.defano.hypertalk.ast.expression.Expression;
+import com.defano.hypertalk.ast.model.Value;
+import com.defano.wyldcard.runtime.ExecutionContext;
+import org.antlr.v4.runtime.ParserRuleContext;
+import java.util.Locale;
+
+public class OSNameFunc extends Expression {
+  public OSNameFunc(ParserRuleContext context) {
+    super(context);
+  }
+
+  @Override
+  protected Value onEvaluate(ExecutionContext context) {
+    String OSName = System.getProperty("os.name");
+    if (OSName == null) {
+      return new Value("");
+    }
+
+    OSName = OSName.toLowerCase(Locale.ENGLISH);
+    if (OSName.contains("windows")) {
+      return new Value("windows");
+    } else if (
+      OSName.contains("linux")   || OSName.contains("mpe/ix") ||
+      OSName.contains("freebsd") || OSName.contains("irix")   ||
+      OSName.contains("unix")
+    ) {
+      return new Value("unix");
+    } else if (OSName.contains("mac os")) {
+      return new Value("macos");
+    } else if (
+      OSName.contains("sun os")  || OSName.contains("sunos") ||
+      OSName.contains("solaris") || OSName.contains("hp-ux") ||
+      OSName.contains("aix")
+    ) {
+      return new Value("posix");
+    } else {
+      return new Value("");
+    }
+  }
+}

--- a/src/main/java/com/defano/hypertalk/ast/expression/function/OSVersionFunc.java
+++ b/src/main/java/com/defano/hypertalk/ast/expression/function/OSVersionFunc.java
@@ -1,0 +1,23 @@
+package com.defano.hypertalk.ast.expression.function;
+
+import com.defano.hypertalk.ast.expression.Expression;
+import com.defano.hypertalk.ast.model.Value;
+import com.defano.wyldcard.runtime.ExecutionContext;
+import org.antlr.v4.runtime.ParserRuleContext;
+import java.util.Locale;
+
+public class OSVersionFunc extends Expression {
+  public OSVersionFunc(ParserRuleContext context) {
+    super(context);
+  }
+
+  @Override
+  protected Value onEvaluate(ExecutionContext context) {
+    String OSVersion = System.getProperty("os.version");
+    if (OSVersion == null) {
+      return new Value("");
+    } else {
+      return new Value(OSVersion.toLowerCase(Locale.ENGLISH));
+    }
+  }
+}

--- a/src/main/java/com/defano/hypertalk/ast/model/enums/BuiltInFunction.java
+++ b/src/main/java/com/defano/hypertalk/ast/model/enums/BuiltInFunction.java
@@ -12,7 +12,7 @@ public enum BuiltInFunction {
     MOUSELOC, MOUSEV, NUM_TO_CHAR, NUMBER, SOUND, SYSTEMVERSION, OFFSET, OPTION_KEY, PARAM, PARAMS, PARAM_COUNT, RANDOM,
     RESULT, SCREENRECT, SECONDS, SELECTEDBUTTON, SELECTEDCHUNK, SELECTEDFIELD, SELECTEDLINE, SELECTEDLOC, SELECTEDTEXT,
     SHIFT_KEY, SHORT_DATE, SHORT_TIME, SIN, SPEECH, SQRT, STACKS, STACKSPACE, SUM, TAN, TARGET, TICKS, TOOL, TRUNC,
-    VALUE, VOICES, WINDOWS, ROUND;
+    VALUE, VOICES, WINDOWS, ROUND, OSNAME, OSVERSION;
 
     public Object asListFunction(ParserRuleContext ctx, Expression listArg) {
         switch (this) {
@@ -129,6 +129,10 @@ public enum BuiltInFunction {
                 return new SoundFunc(ctx);
             case SYSTEMVERSION:
                 return new SystemVersionFunc(ctx);
+            case OSNAME:
+                return new OSNameFunc(ctx);
+            case OSVERSION:
+                return new OSVersionFunc(ctx);
 
             case DESTINATION:
             case SELECTEDBUTTON:


### PR DESCRIPTION
Good morning!

In order to be compatible with macOS systems, it's a good idea to include ".DS_Store" in .gitignore

[Edit] In order to become familiar with the implementation, I've added "the osname" and "the osversion" which determine name and version of the underlying operating system (I also plan to implement a shell command interface in order to enhance the application domain of Wyldcard)