### PR TITLE
Fixed ClickLine function to return the appropriate String

### DIFF
--- a/src/main/antlr/com/defano/hypertalk/parser/HyperTalk.g4
+++ b/src/main/antlr/com/defano/hypertalk/parser/HyperTalk.g4
@@ -561,6 +561,7 @@ zeroArgFunc
     | 'optionkey'                                                                                                       # optionKeyFunc
     | 'osname'                                                                                                          # OSNameFunc
     | 'osversion'                                                                                                       # OSVersionFunc
+    | 'version'                                                                                                         # VersionFunc
     | 'result'                                                                                                          # resultFunc
     | 'screenrect'                                                                                                      # screenRectFunc
     | seconds                                                                                                           # secondsFunc
@@ -780,7 +781,7 @@ keyword
     | 'wipe' | 'zoom' | 'in' | 'out' | 'tick' | 'prev' | 'previous' | 'msg' | 'box' | 'cards' | 'cds' | 'cd'
     | 'background' | 'backgrounds' | 'bkgnd' | 'bkgnds' | 'bg' | 'bgs' | 'buttons' | 'btn' | 'btns' | 'fields' | 'fld'
     | 'flds' | 'character' | 'characters' | 'char' | 'words' | 'lines' | 'item' | 'items' | 'of' | 'osname' | 'osversion'
-    ;
+    | 'version';
 
 picture
     : 'picture'

--- a/src/main/java/com/defano/hypertalk/HyperTalkTreeVisitor.java
+++ b/src/main/java/com/defano/hypertalk/HyperTalkTreeVisitor.java
@@ -2465,6 +2465,11 @@ public class HyperTalkTreeVisitor extends HyperTalkBaseVisitor<Object> {
     }
 
     @Override
+    public Object visitVersionFunc(HyperTalkParser.VersionFuncContext ctx) {
+        return BuiltInFunction.VERSION;
+    }
+
+    @Override
     public Object visitLongTimeFormat(HyperTalkParser.LongTimeFormatContext ctx) {
         return LengthAdjective.LONG;
     }

--- a/src/main/java/com/defano/hypertalk/ast/expression/function/ClickLineFunc.java
+++ b/src/main/java/com/defano/hypertalk/ast/expression/function/ClickLineFunc.java
@@ -2,6 +2,9 @@ package com.defano.hypertalk.ast.expression.function;
 
 import com.defano.hypertalk.ast.expression.Expression;
 import com.defano.hypertalk.ast.model.Value;
+import com.defano.hypertalk.ast.model.enums.Owner;
+import com.defano.hypertalk.ast.model.specifier.PartSpecifier;
+import com.defano.hypertalk.exception.HtException;
 import com.defano.wyldcard.WyldCard;
 import com.defano.wyldcard.runtime.ExecutionContext;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -13,7 +16,21 @@ public class ClickLineFunc extends Expression {
     }
 
     @Override
-    protected Value onEvaluate(ExecutionContext context) {
-        return WyldCard.getInstance().getSelectionManager().getClickLine();
+    protected Value onEvaluate(ExecutionContext context) throws HtException {
+        Value lineValue = WyldCard.getInstance().getSelectionManager().getClickLine();
+        PartSpecifier target = context.getTarget();
+        if (target.getType().hypertalkName.equals("field")){
+            Owner owner = target.getOwner();
+            String ownerHCName = owner.hyperTalkName;
+            Value numberValue = context.getProperty("number", target);
+
+            // eg. "line 2 of card field 1"
+            StringBuilder sb = new StringBuilder().append("line ").append(lineValue).append(" of ").
+                    append(ownerHCName.toLowerCase()).append(" ").append(target.getType().hypertalkName).append(" ").
+                    append(numberValue);
+            return new Value(sb);
+        } else {
+            throw new HtException("the clickLine can only be sent to a Field");
+        }
     }
 }

--- a/src/main/java/com/defano/hypertalk/ast/expression/function/VersionFunc.java
+++ b/src/main/java/com/defano/hypertalk/ast/expression/function/VersionFunc.java
@@ -15,6 +15,6 @@ public class VersionFunc extends Expression {
 
     @Override
     protected Value onEvaluate(ExecutionContext context) {
-        return new Value("2.4.1");
+        return new Value("2.41");
     }
 }

--- a/src/main/java/com/defano/hypertalk/ast/expression/function/VersionFunc.java
+++ b/src/main/java/com/defano/hypertalk/ast/expression/function/VersionFunc.java
@@ -1,0 +1,20 @@
+package com.defano.hypertalk.ast.expression.function;
+
+import com.defano.hypertalk.ast.expression.Expression;
+import com.defano.hypertalk.ast.model.Value;
+import com.defano.wyldcard.runtime.ExecutionContext;
+import org.antlr.v4.runtime.ParserRuleContext;
+
+import java.util.Locale;
+
+public class VersionFunc extends Expression {
+
+    public VersionFunc(ParserRuleContext context) {
+        super(context);
+    }
+
+    @Override
+    protected Value onEvaluate(ExecutionContext context) {
+        return new Value("2.4.1");
+    }
+}

--- a/src/main/java/com/defano/hypertalk/ast/model/enums/BuiltInFunction.java
+++ b/src/main/java/com/defano/hypertalk/ast/model/enums/BuiltInFunction.java
@@ -12,7 +12,7 @@ public enum BuiltInFunction {
     MOUSELOC, MOUSEV, NUM_TO_CHAR, NUMBER, SOUND, SYSTEMVERSION, OFFSET, OPTION_KEY, PARAM, PARAMS, PARAM_COUNT, RANDOM,
     RESULT, SCREENRECT, SECONDS, SELECTEDBUTTON, SELECTEDCHUNK, SELECTEDFIELD, SELECTEDLINE, SELECTEDLOC, SELECTEDTEXT,
     SHIFT_KEY, SHORT_DATE, SHORT_TIME, SIN, SPEECH, SQRT, STACKS, STACKSPACE, SUM, TAN, TARGET, TICKS, TOOL, TRUNC,
-    VALUE, VOICES, WINDOWS, ROUND, OSNAME, OSVERSION;
+    VALUE, VOICES, WINDOWS, ROUND, OSNAME, OSVERSION, VERSION;
 
     public Object asListFunction(ParserRuleContext ctx, Expression listArg) {
         switch (this) {
@@ -133,6 +133,8 @@ public enum BuiltInFunction {
                 return new OSNameFunc(ctx);
             case OSVERSION:
                 return new OSVersionFunc(ctx);
+            case VERSION:
+                return new VersionFunc(ctx);
 
             case DESTINATION:
             case SELECTEDBUTTON:

--- a/src/main/java/com/defano/wyldcard/stackreader/HyperCardStack.java
+++ b/src/main/java/com/defano/wyldcard/stackreader/HyperCardStack.java
@@ -13,7 +13,6 @@ import java.awt.image.BufferedImage;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Stack;
 import java.util.stream.Collectors;
 
 /**
@@ -153,10 +152,7 @@ public class HyperCardStack {
                 Block block = blockType.instantiate(this, blockId, blockSize, blockData);
 
                 blocks.add(block);
-                if (block instanceof StackBlock) {
-                    System.out.println("Carl version:" + block.getMajorVersion(((StackBlock) block).getModifyVersion()));
 
-                }
                 if (block instanceof StackBlock && block.getMajorVersion(((StackBlock) block).getModifyVersion()) < 2) {
                     throw new UnsupportedVersionException(block, "Cannot import stacks from HyperCard 1.x. Please use the \"Convert Stack...\" command in HyperCard 2.x to update this stack.");
                 }
@@ -173,3 +169,4 @@ public class HyperCardStack {
         return ToStringBuilder.reflectionToString(blocks.stream().map(Block::getBlockType).toArray(), ToStringStyle.SIMPLE_STYLE);
     }
 }
+

--- a/src/main/java/com/defano/wyldcard/stackreader/HyperCardStack.java
+++ b/src/main/java/com/defano/wyldcard/stackreader/HyperCardStack.java
@@ -13,6 +13,7 @@ import java.awt.image.BufferedImage;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Stack;
 import java.util.stream.Collectors;
 
 /**
@@ -152,7 +153,10 @@ public class HyperCardStack {
                 Block block = blockType.instantiate(this, blockId, blockSize, blockData);
 
                 blocks.add(block);
+                if (block instanceof StackBlock) {
+                    System.out.println("Carl version:" + block.getMajorVersion(((StackBlock) block).getModifyVersion()));
 
+                }
                 if (block instanceof StackBlock && block.getMajorVersion(((StackBlock) block).getModifyVersion()) < 2) {
                     throw new UnsupportedVersionException(block, "Cannot import stacks from HyperCard 1.x. Please use the \"Convert Stack...\" command in HyperCard 2.x to update this stack.");
                 }

--- a/src/test/java/com/defano/hypertalk/ast/expression/function/ClickLineFuncTest.java
+++ b/src/test/java/com/defano/hypertalk/ast/expression/function/ClickLineFuncTest.java
@@ -1,0 +1,36 @@
+package com.defano.hypertalk.ast.expression.function;
+
+import com.defano.hypertalk.GuiceTest;
+import com.defano.hypertalk.ast.model.Value;
+import com.defano.hypertalk.ast.model.enums.Owner;
+import com.defano.hypertalk.ast.model.specifier.PartSpecifier;
+import com.defano.hypertalk.exception.HtException;
+import com.defano.wyldcard.part.builder.FieldModelBuilder;
+import com.defano.wyldcard.part.field.FieldModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class ClickLineFuncTest extends GuiceTest<ClickLineFunc> {
+
+    @BeforeEach
+    public void setup() {
+        initialize(new ClickLineFunc(mockParserRuleContext));
+    }
+
+    @Test
+    public void testThatClickLineReturnsClickLine() throws HtException {
+        Value expectedLineClickInfo = new Value("line 1 of card field 2");
+        FieldModelBuilder builder = new FieldModelBuilder(Owner.CARD, mockWyldCardPart);
+        FieldModel fieldModel = builder.withText("first\nsecond\nthird").withPartNumber(2).build();
+        fieldModel.setOwner(Owner.CARD);
+        PartSpecifier target = fieldModel.getPartSpecifier(mockExecutionContext);
+        when(mockSelectionManager.getClickLine()).thenReturn(new Value(1));
+        when(mockExecutionContext.getTarget()).thenReturn(fieldModel.getPartSpecifier(mockExecutionContext));
+        when(mockExecutionContext.getProperty("number", target)).thenReturn(new Value(2));
+        assertEquals(uut.onEvaluate(mockExecutionContext), expectedLineClickInfo);
+    }
+
+}

--- a/src/test/java/com/defano/hypertalk/ast/expression/function/VersionFuncTest.java
+++ b/src/test/java/com/defano/hypertalk/ast/expression/function/VersionFuncTest.java
@@ -1,0 +1,40 @@
+package com.defano.hypertalk.ast.expression.function;
+
+import com.defano.hypertalk.GuiceTest;
+import com.defano.hypertalk.ast.expression.Expression;
+import com.defano.hypertalk.ast.model.Value;
+import com.defano.hypertalk.exception.HtSemanticException;
+import com.google.common.collect.Lists;
+import org.junit.Ignore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class VersionFuncTest extends GuiceTest<VersionFunc> {
+
+    private Expression mockExpression = Mockito.mock(Expression.class);
+
+    @BeforeEach
+    public void setUp() {
+
+        initialize(new VersionFunc(mockParserRuleContext));
+    }
+
+    @Test
+    public void testNoArguments() throws Exception {
+        // Setup
+        final Value expectedResult = new Value("2.4.1");
+
+        Mockito.when(mockExpression.evaluateAsList(mockExecutionContext)).thenReturn(Lists.newArrayList());
+
+        // Run the test
+        final Value result = uut.onEvaluate(mockExecutionContext);
+
+        // Verify the results
+        assertEquals(expectedResult, result);
+    }
+
+}

--- a/src/test/java/com/defano/hypertalk/ast/expression/function/VersionFuncTest.java
+++ b/src/test/java/com/defano/hypertalk/ast/expression/function/VersionFuncTest.java
@@ -1,21 +1,12 @@
 package com.defano.hypertalk.ast.expression.function;
 
 import com.defano.hypertalk.GuiceTest;
-import com.defano.hypertalk.ast.expression.Expression;
 import com.defano.hypertalk.ast.model.Value;
-import com.defano.hypertalk.exception.HtSemanticException;
-import com.google.common.collect.Lists;
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class VersionFuncTest extends GuiceTest<VersionFunc> {
-
-    private Expression mockExpression = Mockito.mock(Expression.class);
 
     @BeforeEach
     public void setUp() {
@@ -24,11 +15,9 @@ public class VersionFuncTest extends GuiceTest<VersionFunc> {
     }
 
     @Test
-    public void testNoArguments() throws Exception {
+    public void testTheVersion() {
         // Setup
-        final Value expectedResult = new Value("2.4.1");
-
-        Mockito.when(mockExpression.evaluateAsList(mockExecutionContext)).thenReturn(Lists.newArrayList());
+        final Value expectedResult = new Value("2.41");
 
         // Run the test
         final Value result = uut.onEvaluate(mockExecutionContext);


### PR DESCRIPTION
from returning a single number, to the HC equivalent of "line x of [card | background] field". I had it so it throws an exception when the target is not a field. I suppose, someone might want to programmatically query this function by sending a click event on a mouse location (`mouseLoc`) on top of the field, but they wouldn't know which line to click, as clicking on lines of a field is not a HC or WyldCard command. 

I just realized I missed a negative test. Will do it next time I work on the project.

To physically test this functionality, feel free to use the attached WC stack.
[functional-field-tests.stack.zip](https://github.com/defano/wyldcard/files/8790633/functional-field-tests.stack.zip)
 